### PR TITLE
chore: Fastlane CI/CD 파이프라인 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,22 @@ playground.xcworkspace
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
+fastlane/test_output/
+fastlane/README.md
+
+# Fastlane 빌드 결과물
+*.ipa
+*.dSYM.zip
+
+# SPM 패키지 캐시 (Fastlane 빌드용)
+SourcePackages/
 
 # 개인 설정
 *.xcworkspace
 !default.xcworkspace
 
 # 인증서, 키
+*.p8
 *.p12
 *.mobileprovision
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+# Fastlane 버전 고정 — 팀원 간 동일 버전 보장
+gem "fastlane", "~> 2.227"

--- a/Mople.xcodeproj/project.pbxproj
+++ b/Mople.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		522C4C9D2F875691008B67C8 /* ThemeSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C4C9A2F875691008B67C8 /* ThemeSettingView.swift */; };
 		522C4C9F2F875DE8008B67C8 /* DismissableHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C4C9E2F875DE8008B67C8 /* DismissableHostingController.swift */; };
 		522C4CA02F875DE8008B67C8 /* DismissableHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C4C9E2F875DE8008B67C8 /* DismissableHostingController.swift */; };
+		522C4CA32F878C63008B67C8 /* RxCombine in Frameworks */ = {isa = PBXBuildFile; productRef = 522C4CA22F878C63008B67C8 /* RxCombine */; };
 		5231B6812D41508A0028AF62 /* TransformKeyboardResponsive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5231B6802D41508A0028AF62 /* TransformKeyboardResponsive.swift */; };
 		5231B6832D4150C50028AF62 /* ScrollKeyboardResponsive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5231B6822D4150C50028AF62 /* ScrollKeyboardResponsive.swift */; };
 		5231DF342D2F2A1E00D52529 /* DefaultAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5231DF332D2F2A1E00D52529 /* DefaultAlertViewController.swift */; };
@@ -1274,6 +1275,7 @@
 				52C72EA62C4FBE5900CFF329 /* SnapKit in Frameworks */,
 				52EA6DF82CF75A6600EFD753 /* FirebaseMessaging in Frameworks */,
 				5211F91A2C89E39600403980 /* Kingfisher in Frameworks */,
+				522C4CA32F878C63008B67C8 /* RxCombine in Frameworks */,
 				529A260C2C96AE3E009F4CFA /* RxDataSources in Frameworks */,
 				525DFD052CCB640000835312 /* KakaoSDKCommon in Frameworks */,
 				52C72EA12C4FBE4100CFF329 /* RxRelay in Frameworks */,
@@ -1746,6 +1748,13 @@
 				522C4C9A2F875691008B67C8 /* ThemeSettingView.swift */,
 			);
 			path = ThemeSettingView;
+			sourceTree = "<group>";
+		};
+		522C4CA12F878C63008B67C8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		5231B67F2D41506B0028AF62 /* KeyboardResponsive */ = {
@@ -2810,6 +2819,7 @@
 			isa = PBXGroup;
 			children = (
 				52C72E882C4FBD6400CFF329 /* Mople */,
+				522C4CA12F878C63008B67C8 /* Frameworks */,
 				52C72E872C4FBD6400CFF329 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -3782,6 +3792,7 @@
 				52C013732DC0FFDB00B154F2 /* FirebaseAnalyticsWithoutAdIdSupport */,
 				529291E32DF45EE2005A9453 /* NMapsMap */,
 				52DCFFE52DF5BDC600D0A7E5 /* FirebaseCrashlytics */,
+				522C4CA22F878C63008B67C8 /* RxCombine */,
 			);
 			productName = Mople;
 			productReference = 52C72E862C4FBD6400CFF329 /* Mople.app */;
@@ -4920,7 +4931,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = LNXWGGBBH6;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -4939,7 +4950,7 @@
 					"@executable_path/Frameworks",
 				);
 				MAIN_SCHEME = mople;
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = "";
 				POLICY_URL = "https://unexpected-buckaroo-42a.notion.site/1bc90068602b80788c47c34d1bc3025f?pvs=4";
 				PRODUCT_BUNDLE_IDENTIFIER = com.moim.moimtable;
@@ -4964,10 +4975,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Mople/Mople.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = LNXWGGBBH6;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -4986,13 +4997,13 @@
 					"@executable_path/Frameworks",
 				);
 				MAIN_SCHEME = mople;
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = "";
 				POLICY_URL = "https://unexpected-buckaroo-42a.notion.site/1bc90068602b80788c47c34d1bc3025f?pvs=4";
 				PRODUCT_BUNDLE_IDENTIFIER = com.moim.moimtable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Mople;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Mople Distribution";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -5014,7 +5025,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = LNXWGGBBH6;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -5058,10 +5069,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Dev";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Mople/Mople.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = LNXWGGBBH6;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -5086,7 +5097,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.moim.moimtable.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = MopleDev;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "MopleDev Distribution";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -5238,6 +5249,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5211F9182C89E39600403980 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		522C4CA22F878C63008B67C8 /* RxCombine */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5209D9912F4AC010007757D4 /* XCRemoteSwiftPackageReference "RxCombine" */;
+			productName = RxCombine;
 		};
 		525AA90B2C915C6D0087913F /* FSCalendar */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mople/Dev-Info.plist
+++ b/Mople/Dev-Info.plist
@@ -43,6 +43,8 @@
 	</array>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>KakaoKey</key>
 	<string>$(KAKAO_NATIVE_APP_DEV_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Mople/Info.plist
+++ b/Mople/Info.plist
@@ -43,6 +43,8 @@
 	</array>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>KakaoKey</key>
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Mople/Presentation/MainScene/CommonView/MeetTransfer/TransferMeetView.swift
+++ b/Mople/Presentation/MainScene/CommonView/MeetTransfer/TransferMeetView.swift
@@ -350,6 +350,7 @@ struct TransferConfirmationAlert: View {
 }
 
 // MARK: - Preview
+#if DEV
 #Preview {
     let mockMeet = Meet(
         meetSummary: MeetSummary(id: 1, name: "테스트 모임"),
@@ -358,18 +359,19 @@ struct TransferConfirmationAlert: View {
         memberCount: 5,
         firstPlanDate: nil
     )
-    
+
     let mockFetchMemberUseCase = MockFetchMemberUseCase()
     let mockTransferUseCase = MockTransferMeetUseCase()
-    
+
     let viewModel = TransferMeetViewModel(
         meet: mockMeet,
-        fetchMemberListUseCase: mockFetchMemberUseCase,  // ✅ Mock 주입
+        fetchMemberListUseCase: mockFetchMemberUseCase,
         transferUseCase: mockTransferUseCase
     )
-    
+
     NavigationStack {
         TransferMeetView(viewModel: viewModel)
     }
 }
+#endif
 

--- a/Mople/Presentation/MainScene/Sub/TransferMeet/View/TransferMeetListView.swift
+++ b/Mople/Presentation/MainScene/Sub/TransferMeet/View/TransferMeetListView.swift
@@ -329,6 +329,7 @@ struct DeleteAccountConfirmAlert: View {
 }
 
 // MARK: - Preview
+#if DEV
 #Preview {
     let mockFetchUseCase = MockFetchMyHostMeetsUseCase()
     let mockDeleteUseCase = MockDeleteAccountUseCase()
@@ -339,3 +340,4 @@ struct DeleteAccountConfirmAlert: View {
 
     return TransferMeetListView(viewModel: viewModel)
 }
+#endif

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,9 @@
+# App Store Connect API Key 인증 방식
+# Apple ID/패스워드 대신 API Key로 인증 (2FA 문제 없음, CI/CD에 적합)
+
+# 기본 앱: Mople Dev (TestFlight 테스트용)
+app_identifier("com.moim.moimtable.dev")
+team_id("LNXWGGBBH6")
+
+# release lane에서는 프로덕션 번들 ID를 직접 지정
+# beta lane에서는 dev 번들 ID를 직접 지정

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,132 @@
+# Fastfile — Mople iOS 빌드/배포 자동화
+#
+# 사용법:
+#   fastlane beta          → Mople Dev를 TestFlight에 업로드 (테스트 배포)
+#   fastlane release       → Mople을 App Store에 업로드 (출시)
+#   fastlane build_only    → 빌드만 (업로드 X, 빌드 검증용)
+#
+# 필요 조건:
+#   - App Store Connect API Key (p8 파일)
+#   - 프로비저닝 프로파일 로컬 설치 완료
+#   - Xcode 설치
+
+default_platform(:ios)
+
+# ──────────────────────────────────────────────
+# App Store Connect API Key 설정
+# Apple ID/패스워드 대신 API Key로 인증
+# → 2FA 없이 자동화 가능, CI/CD 필수
+# ──────────────────────────────────────────────
+API_KEY = app_store_connect_api_key(
+  key_id: "9GV3U3P562",
+  issuer_id: "077a4d64-9ada-4316-9cf8-45e9b944ba64",
+  key_filepath: File.join(Dir.home, "Desktop/Task/Develop/Swift/CICD/Release/AuthKey_9GV3U3P562.p8"),
+  in_house: false
+)
+
+platform :ios do
+
+  # ──────────────────────────────────────────
+  # beta: Mople Dev → TestFlight (테스트 배포)
+  # ──────────────────────────────────────────
+  desc "Mople Dev를 TestFlight에 업로드 (테스트용)"
+  lane :beta do |options|
+    # 1) 빌드번호 자동 증가
+    #    App Store Connect에서 Dev앱의 최신 빌드번호를 가져와서 +1
+    increment_build_number(
+      build_number: latest_testflight_build_number(
+        api_key: API_KEY,
+        app_identifier: "com.moim.moimtable.dev"
+      ) + 1
+    )
+
+    # 2) Mople Dev 스킴으로 빌드
+    build_app(
+      project: "Mople.xcodeproj",
+      scheme: "Mople Dev",
+      clean: true,
+      export_method: "app-store",
+      cloned_source_packages_path: "SourcePackages",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          "com.moim.moimtable.dev" => "MopleDev Distribution"
+        }
+      }
+    )
+
+    # 3) TestFlight 업로드
+    #    changelog: 테스트 세부사항 (What to Test)
+    #    사용법: fastlane beta changelog:"변경사항 내용"
+    upload_to_testflight(
+      api_key: API_KEY,
+      app_identifier: "com.moim.moimtable.dev",
+      skip_waiting_for_build_processing: true,
+      changelog: options[:changelog] || "버그 수정 및 기능 개선"
+    )
+
+    UI.success("TestFlight 업로드 완료! (Mople Dev)")
+  end
+
+  # ──────────────────────────────────────────
+  # release: Mople → App Store (출시)
+  # ──────────────────────────────────────────
+  desc "Mople을 App Store에 업로드 (출시용)"
+  lane :release do
+    # 1) 빌드번호 자동 증가
+    increment_build_number(
+      build_number: app_store_build_number(
+        api_key: API_KEY,
+        app_identifier: "com.moim.moimtable"
+      ) + 1
+    )
+
+    # 2) Mople 프로덕션 스킴으로 빌드
+    build_app(
+      project: "Mople.xcodeproj",
+      scheme: "Mople",
+      clean: true,
+      export_method: "app-store",
+      cloned_source_packages_path: "SourcePackages",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          "com.moim.moimtable" => "Mople Distribution"
+        }
+      }
+    )
+
+    # 3) App Store 업로드 (심사 제출은 수동)
+    upload_to_app_store(
+      api_key: API_KEY,
+      skip_metadata: true,
+      skip_screenshots: true,
+      precheck_include_in_app_purchases: false
+    )
+
+    UI.success("App Store 업로드 완료! (Mople)")
+  end
+
+  # ──────────────────────────────────────────
+  # build_only: 빌드 검증만 (업로드 X)
+  # ──────────────────────────────────────────
+  desc "빌드만 수행 (업로드 없음, PR 검증용)"
+  lane :build_only do
+    build_app(
+      project: "Mople.xcodeproj",
+      scheme: "Mople Dev",
+      clean: true,
+      export_method: "app-store",
+      cloned_source_packages_path: "SourcePackages",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          "com.moim.moimtable.dev" => "MopleDev Distribution"
+        }
+      }
+    )
+
+    UI.success("빌드 성공!")
+  end
+
+end


### PR DESCRIPTION
## Summary
- Fastlane 초기 설정 (Fastfile, Appfile, Gemfile)
- `fastlane beta`: Mople Dev → TestFlight 자동 업로드
- `fastlane release`: Mople → App Store 업로드
- App Store Connect API Key 인증 방식 적용
- Distribution 인증서/프로파일 생성 및 Xcode 빌드 설정
- 수출 규정 자동 응답 (ITSAppUsesNonExemptEncryption)
- Preview 코드 #if DEV 조건부 컴파일 처리

## Test plan
- [x] `fastlane beta` → Mople Dev TestFlight 업로드 성공 확인
- [x] `fastlane release` → Mople App Store 업로드 성공 확인
- [ ] 빌드번호 자동 증가 정상 동작 확인

Closes #43